### PR TITLE
A bug that may be triggered on simulated side, UE 5.1.1 and UE 5.5.1 both have this problem

### DIFF
--- a/Source/PredictedMovement/Private/Prone/ProneMovement.cpp
+++ b/Source/PredictedMovement/Private/Prone/ProneMovement.cpp
@@ -468,6 +468,17 @@ void UProneMovement::UpdateCharacterStateBeforeMovement(float DeltaSeconds)
 			}
 		}
 	}
+	else
+	{
+		if (!IsProned() && IsCrouching() && CharacterOwner->GetCapsuleComponent()->GetUnscaledCapsuleHalfHeight() != CrouchedHalfHeight)
+		{
+			// Change collision size to crouching dimensions
+			const float OldUnscaledRadius = CharacterOwner->GetCapsuleComponent()->GetUnscaledCapsuleRadius();
+			// Height is not allowed to be smaller than radius.
+			const float ClampedCrouchedHalfHeight = FMath::Max3(0.f, OldUnscaledRadius, CrouchedHalfHeight);
+			CharacterOwner->GetCapsuleComponent()->SetCapsuleSize(OldUnscaledRadius, ClampedCrouchedHalfHeight);
+		}
+	}
 
 	// Proxies get replicated Prone state.
 	if (CharacterOwner->GetLocalRole() != ROLE_SimulatedProxy)


### PR DESCRIPTION
A bug that may be triggered: When going from Prone to Crouch, ROLE_Authority and ROLE_AutonomousProxy can run normally, but ROLE_SimulatedProxy may not run normally(Character capsule cannot keep crouch, restore to stand). In the Link branch, the following code is added to solve this problem, but it is just temporary way